### PR TITLE
[FEAT] 지수 정보 DB 저장 기능 추가

### DIFF
--- a/AISA/src/main/java/com/AISA/AISA/kisStock/Entity/Index/IndexDailyData.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/Entity/Index/IndexDailyData.java
@@ -1,0 +1,75 @@
+package com.AISA.AISA.kisStock.Entity.Index;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "index_daily_data", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "market_name", "date" })
+})
+public class IndexDailyData {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "market_name", nullable = false, length = 10)
+    private String marketName; // KOSPI, KOSDAQ
+
+    @Column(name = "date", nullable = false)
+    private LocalDate date;
+
+    @Column(name = "opening_price", nullable = false, precision = 20, scale = 2)
+    private BigDecimal openingPrice;
+
+    @Column(name = "closing_price", nullable = false, precision = 20, scale = 2)
+    private BigDecimal closingPrice;
+
+    @Column(name = "high_price", nullable = false, precision = 20, scale = 2)
+    private BigDecimal highPrice;
+
+    @Column(name = "low_price", nullable = false, precision = 20, scale = 2)
+    private BigDecimal lowPrice;
+
+    @Column(name = "price_change", nullable = false, precision = 20, scale = 2)
+    private BigDecimal priceChange;
+
+    @Column(name = "change_rate", nullable = false)
+    private Double changeRate;
+
+    @Column(name = "volume", precision = 20, scale = 0)
+    private BigDecimal volume;
+
+    @Builder
+    public IndexDailyData(String marketName, LocalDate date, BigDecimal openingPrice, BigDecimal closingPrice,
+            BigDecimal highPrice, BigDecimal lowPrice, BigDecimal priceChange, Double changeRate, BigDecimal volume) {
+        this.marketName = marketName;
+        this.date = date;
+        this.openingPrice = openingPrice;
+        this.closingPrice = closingPrice;
+        this.highPrice = highPrice;
+        this.lowPrice = lowPrice;
+        this.priceChange = priceChange;
+        this.changeRate = changeRate;
+        this.volume = volume;
+    }
+
+    public void updateInfo(BigDecimal closingPrice, BigDecimal openingPrice, BigDecimal highPrice, BigDecimal lowPrice,
+            BigDecimal priceChange, Double changeRate, BigDecimal volume) {
+        this.closingPrice = closingPrice;
+        this.openingPrice = openingPrice;
+        this.highPrice = highPrice;
+        this.lowPrice = lowPrice;
+        this.priceChange = priceChange;
+        this.changeRate = changeRate;
+        this.volume = volume;
+    }
+}

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/Entity/stock/Stock.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/Entity/stock/Stock.java
@@ -1,4 +1,4 @@
-package com.AISA.AISA.kisStock.Entity;
+package com.AISA.AISA.kisStock.Entity.stock;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/dto/Index/IndexChartInfoDto.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/dto/Index/IndexChartInfoDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Data
 @Builder
 @NoArgsConstructor

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/dto/Index/IndexChartPriceDto.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/dto/Index/IndexChartPriceDto.java
@@ -5,6 +5,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
 @Data
 @Builder
 @NoArgsConstructor

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/dto/Index/KisIndexDailyPriceDto.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/dto/Index/KisIndexDailyPriceDto.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 @Data
 @NoArgsConstructor
 public class KisIndexDailyPriceDto {

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/kisController/KisStockController.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/kisController/KisStockController.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+
 @RestController
 @RequestMapping("/api/stocks")
 @RequiredArgsConstructor
@@ -27,9 +29,27 @@ public class KisStockController {
     public ResponseEntity<SuccessResponse<IndexChartResponseDto>> getIndexChart(
             @PathVariable String marketCode,
             @RequestParam String date,
-            @RequestParam String dateType
-    ) {
+            @RequestParam String dateType) {
         IndexChartResponseDto chartData = kisStockService.getIndexChart(marketCode, date, dateType);
         return ResponseEntity.ok(new SuccessResponse<>(true, "기간별 지수 정보 조회 성공", chartData));
+    }
+
+    @PostMapping("/indices/{marketCode}/save")
+    @Operation(summary = "지수 데이터 저장", description = "특정 날짜의 지수 데이터를 조회하여 DB에 저장합니다.")
+    public ResponseEntity<SuccessResponse<Void>> saveIndexDailyData(
+            @PathVariable String marketCode,
+            @RequestParam String date,
+            @RequestParam String dateType) {
+        kisStockService.saveIndexDailyData(marketCode, date, dateType);
+        return ResponseEntity.ok(new SuccessResponse<>(true, "지수 데이터 저장 성공", null));
+    }
+
+    @PostMapping("/indices/{marketCode}/init-history")
+    @Operation(summary = "초기 데이터 구축", description = "현재부터 특정 과거 시점까지의 데이터를 반복적으로 수집하여 DB에 저장합니다.")
+    public ResponseEntity<SuccessResponse<Void>> initHistoricalData(
+            @PathVariable String marketCode,
+            @RequestParam String startDate) {
+        kisStockService.fetchAndSaveHistoricalData(marketCode, startDate);
+        return ResponseEntity.ok(new SuccessResponse<>(true, "초기 데이터 구축 시작", null));
     }
 }

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/repository/IndexDailyDataRepository.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/repository/IndexDailyDataRepository.java
@@ -1,0 +1,11 @@
+package com.AISA.AISA.kisStock.repository;
+
+import com.AISA.AISA.kisStock.Entity.Index.IndexDailyData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface IndexDailyDataRepository extends JpaRepository<IndexDailyData, Long> {
+    Optional<IndexDailyData> findByMarketNameAndDate(String marketName, LocalDate date);
+}

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/repository/StockRepository.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/repository/StockRepository.java
@@ -1,6 +1,6 @@
-package com.AISA.AISA.kisStock.Repository;
+package com.AISA.AISA.kisStock.repository;
 
-import com.AISA.AISA.kisStock.Entity.Stock;
+import com.AISA.AISA.kisStock.Entity.stock.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/scheduler/StockScheduler.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/scheduler/StockScheduler.java
@@ -1,0 +1,43 @@
+package com.AISA.AISA.kisStock.scheduler;
+
+import com.AISA.AISA.kisStock.kisService.KisStockService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockScheduler {
+
+    private final KisStockService kisStockService;
+
+    // 매일 오후 4시 30분(16:30)에 실행 (장 마감 후)
+    @Scheduled(cron = "0 30 16 * * *")
+    public void scheduleDailyIndexFetch() {
+        log.info("Starting daily index data fetch...");
+
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+        try {
+            // KOSPI
+            log.info("Fetching daily KOSPI data for {}", today);
+            kisStockService.saveIndexDailyData("KOSPI", today, "D");
+
+            // API 호출 제한 고려 (잠시 대기)
+            Thread.sleep(1000);
+
+            // KOSDAQ
+            log.info("Fetching daily KOSDAQ data for {}", today);
+            kisStockService.saveIndexDailyData("KOSDAQ", today, "D");
+
+            log.info("Daily index data fetch completed successfully.");
+        } catch (Exception e) {
+            log.error("Failed to fetch daily index data: {}", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- close #이슈번호 -->

close #41 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.  -->

코스피와 코스닥의 이전 데이터들을 내 DB에 저장하는 기능 추가
스케쥴러를 사용해 매일 오후 4시 30분에 오늘자 데이터를 DB에 저장하는 기능 추가
한국투자증권 API에는 값들이 대부분 String이였는데, 내 DB에는 LocalDate, BigDecimal, Double 등의 타입으로 저장하도록 설정

## 🛠️ PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## ✅ PR Checklist

- [X] PR 제목 규칙에 맞게 작성 했나요?
- [X] 관련된 이슈 번호를 작성했나요? (<!--- close #이슈번호 -->)
- [X] 모든 변경 사항을 다시 한번 검토했나요?
