### PR TITLE
[FEAT] 개별 종목 및 포트폴리오 수익률 계산 기능 추가

### DIFF
--- a/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/PortStockService.java
+++ b/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/PortStockService.java
@@ -1,0 +1,167 @@
+package com.AISA.AISA.portfolio.PortfolioStock;
+
+import com.AISA.AISA.global.exception.BusinessException;
+import com.AISA.AISA.kisStock.Entity.stock.Stock;
+import com.AISA.AISA.kisStock.dto.StockPrice.StockPriceDto;
+import com.AISA.AISA.kisStock.kisService.KisStockService;
+import com.AISA.AISA.kisStock.repository.StockRepository;
+import com.AISA.AISA.portfolio.PortfolioGroup.Portfolio;
+import com.AISA.AISA.portfolio.PortfolioGroup.PortfolioRepository;
+import com.AISA.AISA.portfolio.PortfolioGroup.exception.PortfolioErrorCode;
+import com.AISA.AISA.portfolio.PortfolioStock.dto.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PortStockService {
+    private final PortStockRepository portStockRepository;
+    private final PortfolioRepository portfolioRepository;
+    private final StockRepository stockRepository;
+    private final KisStockService kisStockService;
+
+    @Transactional
+    public PortStock addStock(UUID portId, PortStockAddRequest request) {
+        Portfolio portfolio = portfolioRepository.findById(portId)
+                .orElseThrow(() -> new BusinessException(PortfolioErrorCode.PORTFOLIO_NOT_FOUND));
+
+        Stock stock = stockRepository.findByStockCode(request.getStockCode())
+                .orElseThrow(() -> new BusinessException(PortfolioErrorCode.STOCK_NOT_FOUND));
+
+        // 이미 존재하는 종목인지 확인
+        return portStockRepository.findByPortfolio_PortIdAndStock_StockCode(portId, request.getStockCode())
+                .map(existingStock -> {
+                    // 존재하면 수량 및 평단가 업데이트 (가중 평균)
+                    int newQuantity = existingStock.getQuantity() + request.getQuantity();
+                    BigDecimal totalCost = existingStock.getAveragePrice()
+                            .multiply(BigDecimal.valueOf(existingStock.getQuantity()))
+                            .add(request.getAveragePrice()
+                                    .multiply(BigDecimal.valueOf(request.getQuantity())));
+                    BigDecimal newAveragePrice = totalCost.divide(BigDecimal.valueOf(newQuantity),
+                            RoundingMode.HALF_UP);
+
+                    existingStock.updateQuantity(newQuantity);
+                    existingStock.updateAveragePrice(newAveragePrice);
+                    return existingStock;
+                })
+                .orElseGet(() -> {
+                    // 존재하지 않으면 새로 생성
+                    Integer maxSequence = portStockRepository.findMaxSequenceByPortfolioId(portId);
+                    int nextSequence = (maxSequence == null) ? 1 : maxSequence + 1;
+
+                    PortStock newStock = new PortStock(
+                            portfolio,
+                            stock,
+                            request.getQuantity(),
+                            request.getAveragePrice(),
+                            nextSequence);
+                    return portStockRepository.save(newStock);
+                });
+    }
+
+    @Transactional
+    public void removeStock(UUID portStockId) {
+        PortStock portStock = portStockRepository.findById(portStockId)
+                .orElseThrow(() -> new BusinessException(PortfolioErrorCode.PORTFOLIO_STOCK_NOT_FOUND));
+
+        int deletedSequence = portStock.getSequence();
+        UUID portId = portStock.getPortfolio().getPortId();
+
+        portStockRepository.delete(portStock);
+
+        // 삭제된 종목보다 뒤에 있는 종목들의 sequence를 1씩 당김
+        List<PortStock> stocksToShift = portStockRepository.findByPortfolio_PortIdAndSequenceGreaterThan(portId,
+                deletedSequence);
+        for (PortStock stock : stocksToShift) {
+            stock.updateSequence(stock.getSequence() - 1);
+        }
+    }
+
+    @Transactional
+    public void updateStock(UUID portStockId, PortStockUpdateRequest request) {
+        PortStock portStock = portStockRepository.findById(portStockId)
+                .orElseThrow(() -> new BusinessException(PortfolioErrorCode.PORTFOLIO_STOCK_NOT_FOUND));
+
+        if (request.getQuantity() != null) {
+            portStock.updateQuantity(request.getQuantity());
+        }
+        if (request.getAveragePrice() != null) {
+            portStock.updateAveragePrice(request.getAveragePrice());
+        }
+        if (request.getSequence() != null) {
+            int newSequence = request.getSequence();
+            int oldSequence = portStock.getSequence();
+            UUID portId = portStock.getPortfolio().getPortId();
+
+            if (newSequence != oldSequence) {
+                long totalCount = portStockRepository.countByPortfolio_PortId(portId);
+                if (newSequence < 1 || newSequence > totalCount) {
+                    throw new BusinessException(PortfolioErrorCode.INVALID_SEQUENCE);
+                }
+
+                if (newSequence < oldSequence) {
+                    // 위로 이동: newSequence ~ oldSequence - 1 까지의 종목들을 +1
+                    List<PortStock> stocksToShift = portStockRepository.findByPortfolio_PortIdAndSequenceBetween(portId,
+                            newSequence, oldSequence - 1);
+                    for (PortStock stock : stocksToShift) {
+                        stock.updateSequence(stock.getSequence() + 1);
+                    }
+                } else {
+                    // 아래로 이동: oldSequence + 1 ~ newSequence 까지의 종목들을 -1
+                    List<PortStock> stocksToShift = portStockRepository.findByPortfolio_PortIdAndSequenceBetween(portId,
+                            oldSequence + 1, newSequence);
+                    for (PortStock stock : stocksToShift) {
+                        stock.updateSequence(stock.getSequence() - 1);
+                    }
+                }
+                portStock.updateSequence(newSequence);
+            }
+        }
+    }
+
+    public List<PortStockResponse> getPortStocks(UUID portId) {
+        if (!portfolioRepository.existsById(portId)) {
+            throw new BusinessException(PortfolioErrorCode.PORTFOLIO_NOT_FOUND);
+        }
+        return portStockRepository.findByPortfolio_PortIdOrderBySequenceAsc(portId).stream()
+                .map(PortStockResponse::new)
+                .collect(toList());
+    }
+
+    public PortfolioReturnResponse getPortfolioReturn(UUID portId) {
+        Portfolio portfolio = portfolioRepository.findById(portId)
+                .orElseThrow(() -> new BusinessException(PortfolioErrorCode.PORTFOLIO_NOT_FOUND));
+
+        List<PortStock> portStocks = portStockRepository.findByPortfolio_PortIdOrderBySequenceAsc(portId);
+
+        List<PortStockReturnResponse> stockReturns = portStocks.stream()
+                .map(portStock -> {
+                    try {
+                        // KIS API를 통해 현재가 조회
+                        StockPriceDto stockPriceDto = kisStockService
+                                .getStockPrice(portStock.getStock().getStockCode());
+                        BigDecimal currentPrice = new BigDecimal(stockPriceDto.getStockPrice());
+                        return new PortStockReturnResponse(portStock,
+                                currentPrice);
+                    } catch (Exception e) {
+                        // API 호출 실패 시 현재가를 0으로 처리하거나 예외 처리 (여기서는 0으로 처리하여 전체 로직이 깨지지 않도록 함)
+                        // 실제 운영 환경에서는 로그를 남기고 사용자에게 알리는 것이 좋음
+                        return new PortStockReturnResponse(portStock,
+                                BigDecimal.ZERO);
+                    }
+                })
+                .collect(toList());
+
+        return new PortfolioReturnResponse(portfolio, stockReturns);
+    }
+}

--- a/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortStockAddRequest.java
+++ b/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortStockAddRequest.java
@@ -1,0 +1,20 @@
+package com.AISA.AISA.portfolio.PortfolioStock.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+public class PortStockAddRequest {
+    private String stockCode;
+    private Integer quantity;
+    private BigDecimal averagePrice;
+
+    public PortStockAddRequest(String stockCode, Integer quantity, BigDecimal averagePrice) {
+        this.stockCode = stockCode;
+        this.quantity = quantity;
+        this.averagePrice = averagePrice;
+    }
+}

--- a/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortStockResponse.java
+++ b/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortStockResponse.java
@@ -1,0 +1,28 @@
+package com.AISA.AISA.portfolio.PortfolioStock.dto;
+
+import com.AISA.AISA.portfolio.PortfolioStock.PortStock;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class PortStockResponse {
+    private UUID portStockId;
+    private String stockCode;
+    private String stockName;
+    private Integer quantity;
+    private BigDecimal averagePrice;
+    private Integer sequence;
+
+    public PortStockResponse(PortStock portStock) {
+        this.portStockId = portStock.getId();
+        this.stockCode = portStock.getStock().getStockCode();
+        this.stockName = portStock.getStock().getStockName();
+        this.quantity = portStock.getQuantity();
+        this.averagePrice = portStock.getAveragePrice();
+        this.sequence = portStock.getSequence();
+    }
+}

--- a/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortStockReturnResponse.java
+++ b/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortStockReturnResponse.java
@@ -1,0 +1,33 @@
+package com.AISA.AISA.portfolio.PortfolioStock.dto;
+
+import com.AISA.AISA.portfolio.PortfolioStock.PortStock;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Getter
+@NoArgsConstructor
+public class PortStockReturnResponse extends PortStockResponse {
+    private BigDecimal currentPrice;
+    private BigDecimal totalValue; // 평가금액
+    private BigDecimal investmentAmount; // 매수금액
+    private BigDecimal profitOrLoss; // 평가손익
+    private BigDecimal returnRate; // 수익률
+
+    public PortStockReturnResponse(PortStock portStock, BigDecimal currentPrice) {
+        super(portStock);
+        this.currentPrice = currentPrice;
+        this.investmentAmount = portStock.getAveragePrice().multiply(BigDecimal.valueOf(portStock.getQuantity()));
+        this.totalValue = currentPrice.multiply(BigDecimal.valueOf(portStock.getQuantity()));
+        this.profitOrLoss = this.totalValue.subtract(this.investmentAmount);
+
+        if (this.investmentAmount.compareTo(BigDecimal.ZERO) == 0) {
+            this.returnRate = BigDecimal.ZERO;
+        } else {
+            this.returnRate = this.profitOrLoss.divide(this.investmentAmount, 4, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100));
+        }
+    }
+}

--- a/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortStockUpdateRequest.java
+++ b/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortStockUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.AISA.AISA.portfolio.PortfolioStock.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+public class PortStockUpdateRequest {
+    private Integer quantity;
+    private BigDecimal averagePrice;
+    private Integer sequence;
+
+    public PortStockUpdateRequest(Integer quantity, BigDecimal averagePrice, Integer sequence) {
+        this.quantity = quantity;
+        this.averagePrice = averagePrice;
+        this.sequence = sequence;
+    }
+}

--- a/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortfolioReturnResponse.java
+++ b/AISA/src/main/java/com/AISA/AISA/portfolio/PortfolioStock/dto/PortfolioReturnResponse.java
@@ -1,0 +1,46 @@
+package com.AISA.AISA.portfolio.PortfolioStock.dto;
+
+import com.AISA.AISA.portfolio.PortfolioGroup.Portfolio;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class PortfolioReturnResponse {
+    private UUID portId;
+    private String portName;
+    private BigDecimal totalValue; // 총 평가금액
+    private BigDecimal totalInvestmentAmount; // 총 매수금액
+    private BigDecimal totalProfitOrLoss; // 총 평가손익
+    private BigDecimal totalReturnRate; // 총 수익률
+    private List<PortStockReturnResponse> stockReturns;
+
+    public PortfolioReturnResponse(Portfolio portfolio, List<PortStockReturnResponse> stockReturns) {
+        this.portId = portfolio.getPortId();
+        this.portName = portfolio.getPortName();
+        this.stockReturns = stockReturns;
+
+        this.totalValue = stockReturns.stream()
+                .map(PortStockReturnResponse::getTotalValue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        this.totalInvestmentAmount = stockReturns.stream()
+                .map(PortStockReturnResponse::getInvestmentAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        this.totalProfitOrLoss = this.totalValue.subtract(this.totalInvestmentAmount);
+
+        if (this.totalInvestmentAmount.compareTo(BigDecimal.ZERO) == 0) {
+            this.totalReturnRate = BigDecimal.ZERO;
+        } else {
+            this.totalReturnRate = this.totalProfitOrLoss
+                    .divide(this.totalInvestmentAmount, 4, RoundingMode.HALF_UP)
+                    .multiply(BigDecimal.valueOf(100));
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- close #이슈번호 -->

close #50 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.  -->

포트폴리오 내 각 종목의 현재가를 조회하여 수익률(평가손익, 수익률)을 계산하고, 포트폴리오 전체의 총 자산, 총 투자금액, 총 수익률을 제공하는 기능 구현

## 🛠️ PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## ✅ PR Checklist

- [X] PR 제목 규칙에 맞게 작성 했나요?
- [X] 관련된 이슈 번호를 작성했나요? (<!--- close #이슈번호 -->)
- [X] 모든 변경 사항을 다시 한번 검토했나요?
