### PR TITLE
[FEAT] 주식 과거 데이터 조회 기능 추가

### DIFF
--- a/AISA/src/main/java/com/AISA/AISA/kisStock/Entity/stock/StockDailyData.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/Entity/stock/StockDailyData.java
@@ -1,0 +1,63 @@
+package com.AISA.AISA.kisStock.Entity.stock;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "stock_daily_data", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "stock_id", "date" })
+})
+public class StockDailyData {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "stock_id", nullable = false)
+    private Stock stock;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private BigDecimal closingPrice;
+
+    @Column(nullable = false)
+    private BigDecimal openingPrice;
+
+    @Column(nullable = false)
+    private BigDecimal highPrice;
+
+    @Column(nullable = false)
+    private BigDecimal lowPrice;
+
+    @Column(nullable = false)
+    private BigDecimal volume;
+
+    private BigDecimal priceChange;
+
+    private Double changeRate;
+
+    @Builder
+    public StockDailyData(Stock stock, LocalDate date, BigDecimal closingPrice, BigDecimal openingPrice,
+            BigDecimal highPrice, BigDecimal lowPrice, BigDecimal volume,
+            BigDecimal priceChange, Double changeRate) {
+        this.stock = stock;
+        this.date = date;
+        this.closingPrice = closingPrice;
+        this.openingPrice = openingPrice;
+        this.highPrice = highPrice;
+        this.lowPrice = lowPrice;
+        this.volume = volume;
+        this.priceChange = priceChange;
+        this.changeRate = changeRate;
+    }
+}

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/config/KisApiProperties.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/config/KisApiProperties.java
@@ -15,6 +15,7 @@ public class KisApiProperties {
     private String priceUrl;
     private String indexPriceUrl;
     private String indexChartUrl;
+    private String stockChartUrl;
     private String appkey;
     private String appsecret;
 }

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/dto/StockPrice/StockChartPriceDto.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/dto/StockPrice/StockChartPriceDto.java
@@ -1,0 +1,31 @@
+package com.AISA.AISA.kisStock.dto.StockPrice;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockChartPriceDto {
+    @JsonProperty("stck_bsop_date")
+    private String date;
+
+    @JsonProperty("stck_clpr")
+    private String closePrice;
+
+    @JsonProperty("stck_oprc")
+    private String openPrice;
+
+    @JsonProperty("stck_hgpr")
+    private String highPrice;
+
+    @JsonProperty("stck_lwpr")
+    private String lowPrice;
+
+    @JsonProperty("acml_vol")
+    private String volume;
+}

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/dto/StockPrice/StockChartResponseDto.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/dto/StockPrice/StockChartResponseDto.java
@@ -1,0 +1,24 @@
+package com.AISA.AISA.kisStock.dto.StockPrice;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StockChartResponseDto {
+    @JsonProperty("rt_cd")
+    private String rtCd;
+
+    @JsonProperty("msg1")
+    private String msg1;
+
+    @JsonProperty("output2")
+    private List<StockChartPriceDto> priceList;
+}

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/kisController/KisIndexController.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/kisController/KisIndexController.java
@@ -1,0 +1,56 @@
+package com.AISA.AISA.kisStock.kisController;
+
+import com.AISA.AISA.global.response.SuccessResponse;
+import com.AISA.AISA.kisStock.dto.Index.IndexChartInfoDto;
+import com.AISA.AISA.kisStock.dto.Index.IndexChartResponseDto;
+import com.AISA.AISA.kisStock.kisService.KisIndexService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/indices")
+@RequiredArgsConstructor
+@Tag(name = "지수 API", description = "지수 관련 API")
+public class KisIndexController {
+    private final KisIndexService kisIndexService;
+
+    @GetMapping("/{marketCode}/status")
+    @Operation(summary = "지수 현재 상태 조회", description = "코스피(kospi) / 코스닥(kosdaq)의 실시간 지수 정보를 조회합니다.")
+    public ResponseEntity<SuccessResponse<IndexChartInfoDto>> getIndexStatus(@PathVariable String marketCode) {
+        IndexChartInfoDto statusData = kisIndexService.getIndexStatus(marketCode);
+        return ResponseEntity.ok(new SuccessResponse<>(true, "지수 현재 상태 조회 성공", statusData));
+    }
+
+    @GetMapping("/{marketCode}/chart")
+    @Operation(summary = "지수 조회", description = "코스피(kospi) / 코스닥(kosdaq)의 날짜별 정보를 조회합니다.")
+    public ResponseEntity<SuccessResponse<IndexChartResponseDto>> getIndexChart(
+            @PathVariable String marketCode,
+            @RequestParam String startDate,
+            @RequestParam String endDate,
+            @RequestParam(defaultValue = "D") String dateType) {
+        IndexChartResponseDto chartData = kisIndexService.getIndexChart(marketCode, startDate, endDate, dateType);
+        return ResponseEntity.ok(new SuccessResponse<>(true, "기간별 지수 정보 조회 성공", chartData));
+    }
+
+    @PostMapping("/{marketCode}/save")
+    @Operation(summary = "지수 데이터 저장", description = "특정 날짜의 지수 데이터를 조회하여 DB에 저장합니다.")
+    public ResponseEntity<SuccessResponse<Void>> saveIndexDailyData(
+            @PathVariable String marketCode,
+            @RequestParam String date,
+            @RequestParam(defaultValue = "D") String dateType) {
+        kisIndexService.saveIndexDailyData(marketCode, date, dateType);
+        return ResponseEntity.ok(new SuccessResponse<>(true, "지수 데이터 저장 성공", null));
+    }
+
+    @PostMapping("/{marketCode}/init-history")
+    @Operation(summary = "초기 지수 데이터 구축", description = "현재부터 특정 과거 시점까지의 데이터를 반복적으로 수집하여 DB에 저장합니다.")
+    public ResponseEntity<SuccessResponse<Void>> initHistoricalData(
+            @PathVariable String marketCode,
+            @RequestParam String startDate) {
+        kisIndexService.fetchAndSaveHistoricalData(marketCode, startDate);
+        return ResponseEntity.ok(new SuccessResponse<>(true, "초기 데이터 구축 시작", null));
+    }
+}

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/kisController/KisStockController.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/kisController/KisStockController.java
@@ -1,8 +1,7 @@
 package com.AISA.AISA.kisStock.kisController;
 
 import com.AISA.AISA.global.response.SuccessResponse;
-import com.AISA.AISA.kisStock.dto.Index.IndexChartInfoDto;
-import com.AISA.AISA.kisStock.dto.Index.IndexChartResponseDto;
+import com.AISA.AISA.kisStock.dto.StockPrice.StockChartResponseDto;
 import com.AISA.AISA.kisStock.dto.StockPrice.StockPriceDto;
 import com.AISA.AISA.kisStock.kisService.KisStockService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/stocks")
 @RequiredArgsConstructor
-@Tag(name = "주식 API", description = "주식과 지수 관련 API")
+@Tag(name = "주식 API", description = "주식 관련 API")
 public class KisStockController {
     private final KisStockService kisStockService;
 
@@ -25,40 +24,38 @@ public class KisStockController {
         return ResponseEntity.ok(new SuccessResponse<>(true, "주식 현재가 조회 성공", stockPriceDto));
     }
 
-    @GetMapping("/indices/{marketCode}/status")
-    @Operation(summary = "지수 현재 상태 조회", description = "코스피(kospi) / 코스닥(kosdaq)의 실시간 지수 정보를 조회합니다.")
-    public ResponseEntity<SuccessResponse<IndexChartInfoDto>> getIndexStatus(@PathVariable String marketCode) {
-        IndexChartInfoDto statusData = kisStockService.getIndexStatus(marketCode);
-        return ResponseEntity.ok(new SuccessResponse<>(true, "지수 현재 상태 조회 성공", statusData));
-    }
-
-    @GetMapping("/indices/{marketCode}/chart")
-    @Operation(summary = "지수 조회", description = "코스피(kospi) / 코스닥(kosdaq)의 날짜별 정보를 조회합니다.")
-    public ResponseEntity<SuccessResponse<IndexChartResponseDto>> getIndexChart(
-            @PathVariable String marketCode,
+    @GetMapping("/{stockCode}/chart")
+    @Operation(summary = "주식 차트 조회", description = "특정 주식의 날짜별 차트 정보를 조회합니다.")
+    public ResponseEntity<SuccessResponse<StockChartResponseDto>> getStockChart(
+            @PathVariable String stockCode,
             @RequestParam String startDate,
             @RequestParam String endDate,
             @RequestParam(defaultValue = "D") String dateType) {
-        IndexChartResponseDto chartData = kisStockService.getIndexChart(marketCode, startDate, endDate, dateType);
-        return ResponseEntity.ok(new SuccessResponse<>(true, "기간별 지수 정보 조회 성공", chartData));
+        StockChartResponseDto chartData = kisStockService.getStockChart(stockCode, startDate, endDate, dateType);
+        return ResponseEntity.ok(new SuccessResponse<>(true, "주식 차트 정보 조회 성공", chartData));
     }
 
-    @PostMapping("/indices/{marketCode}/save")
-    @Operation(summary = "지수 데이터 저장", description = "특정 날짜의 지수 데이터를 조회하여 DB에 저장합니다.")
-    public ResponseEntity<SuccessResponse<Void>> saveIndexDailyData(
-            @PathVariable String marketCode,
-            @RequestParam String date,
-            @RequestParam(defaultValue = "D") String dateType) {
-        kisStockService.saveIndexDailyData(marketCode, date, dateType);
-        return ResponseEntity.ok(new SuccessResponse<>(true, "지수 데이터 저장 성공", null));
-    }
-
-    @PostMapping("/indices/{marketCode}/init-history")
-    @Operation(summary = "초기 지수 데이터 구축", description = "현재부터 특정 과거 시점까지의 데이터를 반복적으로 수집하여 DB에 저장합니다.")
+    @PostMapping("/{stockCode}/init-history")
+    @Operation(summary = "초기 주식 데이터 구축", description = "현재부터 특정 과거 시점까지의 데이터를 반복적으로 수집하여 DB에 저장합니다.")
     public ResponseEntity<SuccessResponse<Void>> initHistoricalData(
-            @PathVariable String marketCode,
+            @PathVariable String stockCode,
             @RequestParam String startDate) {
-        kisStockService.fetchAndSaveHistoricalData(marketCode, startDate);
+        kisStockService.fetchAndSaveHistoricalStockData(stockCode, startDate);
         return ResponseEntity.ok(new SuccessResponse<>(true, "초기 데이터 구축 시작", null));
+    }
+
+    @PostMapping("/init-history/all")
+    @Operation(summary = "전체 주식 초기 데이터 구축", description = "모든 주식에 대해 현재부터 특정 과거 시점까지의 데이터를 반복적으로 수집하여 DB에 저장합니다. (비동기 실행 권장)")
+    public ResponseEntity<SuccessResponse<String>> initHistoricalDataAll(@RequestParam String startDate) {
+        // 비동기로 실행하거나, 그냥 실행하고 "Started" 반환
+        // 여기서는 간단히 실행 (시간이 오래 걸릴 수 있음) - 실제 운영 환경에서는 @Async 등을 고려해야 함
+        // CompletableFuture.runAsync(() ->
+        // kisStockService.fetchAllStocksHistoricalData(startDate));
+
+        // 사용자의 요청에 따라 동기적으로 실행하거나, 별도 스레드에서 실행
+        new Thread(() -> kisStockService.fetchAllStocksHistoricalData(startDate)).start();
+
+        return ResponseEntity
+                .ok(new SuccessResponse<>(true, "전체 주식 초기 데이터 구축 시작 (백그라운드 실행)", "Started background task"));
     }
 }

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/kisService/KisIndexService.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/kisService/KisIndexService.java
@@ -1,0 +1,349 @@
+package com.AISA.AISA.kisStock.kisService;
+
+import com.AISA.AISA.kisStock.Entity.Index.IndexDailyData;
+import com.AISA.AISA.kisStock.config.KisApiProperties;
+import com.AISA.AISA.kisStock.dto.Index.IndexChartInfoDto;
+import com.AISA.AISA.kisStock.dto.Index.IndexChartPriceDto;
+import com.AISA.AISA.kisStock.dto.Index.IndexChartResponseDto;
+import com.AISA.AISA.kisStock.dto.Index.KisIndexChartApiResponse;
+import com.AISA.AISA.kisStock.exception.KisApiErrorCode;
+import com.AISA.AISA.kisStock.kisService.Auth.KisAuthService;
+import com.AISA.AISA.kisStock.repository.IndexDailyDataRepository;
+import com.AISA.AISA.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KisIndexService {
+
+    private final WebClient webClient;
+    private final KisAuthService kisAuthService;
+    private final KisApiProperties kisApiProperties;
+    private final IndexDailyDataRepository indexDailyDataRepository;
+
+    @Transactional
+    public void fetchAndSaveHistoricalData(String marketCode, String startDateStr) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        LocalDate targetStartDate = LocalDate.parse(startDateStr, formatter);
+        LocalDate currentDate = LocalDate.now();
+
+        log.info("Starting historical data fetch for {} from {} to {}", marketCode, currentDate,
+                targetStartDate);
+
+        int consecutiveFailures = 0;
+        final int MAX_CONSECUTIVE_FAILURES = 5;
+
+        while (currentDate.isAfter(targetStartDate)) {
+            String currentDateStr = currentDate.format(formatter);
+            log.info("Fetching data for date: {}", currentDateStr);
+
+            try {
+                // 1. API 호출 및 데이터 가져오기
+                IndexChartResponseDto response = fetchIndexChartFromApi(marketCode, currentDateStr,
+                        "D");
+
+                if (response.getPriceList() == null || response.getPriceList().isEmpty()) {
+                    log.warn("No data returned for date: {}. Retrying with previous day.", currentDateStr);
+                    currentDate = currentDate.minusDays(1);
+                    consecutiveFailures++;
+                    if (consecutiveFailures > MAX_CONSECUTIVE_FAILURES) {
+                        log.error("Too many consecutive failures ({}). Stopping.", consecutiveFailures);
+                        break;
+                    }
+                    continue;
+                }
+
+                // Reset failure counter on success
+                consecutiveFailures = 0;
+
+                // 2. 데이터 저장
+                for (IndexChartPriceDto priceDto : response.getPriceList()) {
+                    LocalDate parsedDate = LocalDate.parse(priceDto.getDate(), formatter);
+
+                    // 이미 저장된 데이터가 있으면 건너뛰기 (옵션)
+                    if (indexDailyDataRepository.findByMarketNameAndDate(marketCode, parsedDate)
+                            .isPresent()) {
+                        continue;
+                    }
+
+                    IndexDailyData entity = IndexDailyData.builder()
+                            .marketName(marketCode)
+                            .date(parsedDate)
+                            .closingPrice(new BigDecimal(priceDto.getPrice()))
+                            .openingPrice(new BigDecimal(priceDto.getOpenPrice()))
+                            .highPrice(new BigDecimal(priceDto.getHighPrice()))
+                            .lowPrice(new BigDecimal(priceDto.getLowPrice()))
+                            .priceChange(BigDecimal.ZERO)
+                            .changeRate(0.0)
+                            .volume(BigDecimal.ZERO)
+                            .build();
+
+                    indexDailyDataRepository.save(entity);
+                }
+
+                // 3. 다음 호출을 위해 날짜 갱신 (가장 과거 날짜 - 1일)
+                String oldestDateStr = response.getPriceList().get(response.getPriceList().size() - 1)
+                        .getDate();
+                LocalDate oldestDate = LocalDate.parse(oldestDateStr, formatter);
+
+                if (!oldestDate.isBefore(currentDate)) {
+                    // 무한 루프 방지: API가 계속 같은 날짜를 반환하거나 이상할 경우
+                    log.warn("Oldest date {} is not before current date {}. Stopping to prevent infinite loop.",
+                            oldestDate, currentDate);
+                    break;
+                }
+
+                currentDate = oldestDate.minusDays(1);
+
+                // API 호출 제한 고려 (0.1초 대기)
+                Thread.sleep(100);
+
+            } catch (Exception e) {
+                log.error("Error fetching historical data for {}: {}", currentDateStr, e.getMessage());
+                // Instead of breaking, try previous day
+                currentDate = currentDate.minusDays(1);
+                consecutiveFailures++;
+                if (consecutiveFailures > MAX_CONSECUTIVE_FAILURES) {
+                    log.error("Too many consecutive failures ({}). Stopping.", consecutiveFailures);
+                    break;
+                }
+            }
+        }
+        log.info("Finished historical data fetch for {}", marketCode);
+    }
+
+    @Transactional
+    public void saveIndexDailyData(String marketCode, String date, String dateType) {
+        IndexChartResponseDto response = fetchIndexChartFromApi(marketCode, date, dateType);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        for (IndexChartPriceDto priceDto : response.getPriceList()) {
+            LocalDate parsedDate = LocalDate.parse(priceDto.getDate(), formatter);
+
+            if (indexDailyDataRepository.findByMarketNameAndDate(marketCode, parsedDate).isPresent()) {
+                continue;
+            }
+
+            IndexDailyData entity = IndexDailyData.builder()
+                    .marketName(marketCode)
+                    .date(parsedDate)
+                    .closingPrice(new BigDecimal(priceDto.getPrice()))
+                    .openingPrice(new BigDecimal(priceDto.getOpenPrice()))
+                    .highPrice(new BigDecimal(priceDto.getHighPrice()))
+                    .lowPrice(new BigDecimal(priceDto.getLowPrice()))
+                    .priceChange(BigDecimal.ZERO) // DTO에 없으면 0 또는 계산
+                    .changeRate(0.0) // DTO에 없으면 0 또는 계산
+                    .volume(BigDecimal.ZERO) // DTO에 volume이 없다면 0 처리, 있다면 new
+                    // BigDecimal(priceDto.getVolume())
+                    .build();
+
+            indexDailyDataRepository.save(entity);
+        }
+    }
+
+    // DB에서 조회하는 메서드 (Controller에서 사용)
+    public IndexChartResponseDto getIndexChart(String marketCode, String startDate, String endDate,
+            String dateType) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        LocalDate targetEndDate = LocalDate.parse(endDate, formatter);
+        LocalDate targetStartDate = LocalDate.parse(startDate, formatter);
+
+        try {
+            // 1. 실시간 데이터(API) 시도 (endDate 기준 100건)
+            IndexChartResponseDto apiResponse = fetchIndexChartFromApi(marketCode, endDate, dateType);
+
+            // API 데이터가 없으면 DB만 조회
+            if (apiResponse.getPriceList() == null || apiResponse.getPriceList().isEmpty()) {
+                throw new BusinessException(KisApiErrorCode.INDEX_FETCH_FAILED);
+            }
+
+            // 2. API 데이터 필터링 (startDate보다 이후인 데이터만 사용)
+            List<IndexChartPriceDto> filteredApiList = apiResponse.getPriceList().stream()
+                    .filter(dto -> {
+                        LocalDate dtoDate = LocalDate.parse(dto.getDate(), formatter);
+                        return !dtoDate.isBefore(targetStartDate)
+                                && !dtoDate.isAfter(targetEndDate);
+                    })
+                    .toList();
+
+            // 3. 부족한 과거 데이터 DB 조회
+            List<IndexChartPriceDto> dbPriceList = new ArrayList<>();
+
+            // API 데이터가 있고, 가장 오래된 날짜가 startDate보다 아직 미래라면 -> 그 사이 공백을 DB로 채움
+            if (!filteredApiList.isEmpty()) {
+                String oldestApiDateStr = filteredApiList.get(filteredApiList.size() - 1).getDate();
+                LocalDate oldestApiDate = LocalDate.parse(oldestApiDateStr, formatter);
+
+                if (oldestApiDate.isAfter(targetStartDate)) {
+                    List<IndexDailyData> pastDataList = indexDailyDataRepository
+                            .findAllByMarketNameAndDateBetweenOrderByDateDesc(
+                                    marketCode, targetStartDate,
+                                    oldestApiDate.minusDays(1));
+
+                    dbPriceList = pastDataList.stream()
+                            .map(this::convertToDto)
+                            .collect(Collectors.toList());
+                }
+            } else {
+                // API 데이터가 startDate 범위에 하나도 없으면 (API가 너무 미래 데이터만 줬거나 등)
+                // DB에서 전체 범위 조회 시도 (API가 준 데이터의 가장 오래된 날짜보다 더 과거를 요청했을 수 있음)
+                // 하지만 fetchIndexChartFromApi는 endDate 기준 100개를 주므로,
+                // endDate가 startDate보다 훨씬 미래라면 API 데이터가 startDate를 커버하지 못할 수 있음.
+                // 이 경우 API 데이터 전체(100개) + 그 이전 DB 데이터를 합쳐야 하는데,
+                // 여기서는 단순하게 "API가 커버하지 못하는 영역"을 DB에서 가져오는 로직으로 처리
+
+                // API가 반환한 가장 오래된 날짜 확인
+                String apiOldestRaw = apiResponse.getPriceList()
+                        .get(apiResponse.getPriceList().size() - 1).getDate();
+                LocalDate apiOldestDate = LocalDate.parse(apiOldestRaw, formatter);
+
+                if (apiOldestDate.isAfter(targetStartDate)) {
+                    List<IndexDailyData> pastDataList = indexDailyDataRepository
+                            .findAllByMarketNameAndDateBetweenOrderByDateDesc(
+                                    marketCode, targetStartDate,
+                                    apiOldestDate.minusDays(1));
+                    dbPriceList = pastDataList.stream()
+                            .map(this::convertToDto)
+                            .collect(Collectors.toList());
+                }
+            }
+
+            // 4. 데이터 병합
+            List<IndexChartPriceDto> mergedList = new ArrayList<>(filteredApiList);
+            mergedList.addAll(dbPriceList);
+
+            return IndexChartResponseDto.builder()
+                    .info(apiResponse.getInfo())
+                    .priceList(mergedList)
+                    .build();
+
+        } catch (Exception e) {
+            log.warn("Failed to fetch from API, falling back to DB: {}", e.getMessage());
+
+            // API 실패 시 DB에서 전체 범위 조회
+            List<IndexDailyData> entityList = indexDailyDataRepository
+                    .findAllByMarketNameAndDateBetweenOrderByDateDesc(marketCode, targetStartDate,
+                            targetEndDate);
+
+            if (entityList.isEmpty()) {
+                throw new BusinessException(KisApiErrorCode.INDEX_FETCH_FAILED);
+            }
+
+            IndexDailyData todayData = entityList.get(0);
+
+            IndexChartInfoDto chartInfoDto = IndexChartInfoDto.builder()
+                    .marketName(marketCode.toUpperCase())
+                    .currentIndices(todayData.getClosingPrice().toString())
+                    .priceChange(todayData.getPriceChange().toString())
+                    .changeRate(todayData.getChangeRate().toString())
+                    .build();
+
+            List<IndexChartPriceDto> chartPriceList = entityList.stream()
+                    .map(this::convertToDto)
+                    .collect(Collectors.toList());
+
+            return IndexChartResponseDto.builder()
+                    .info(chartInfoDto)
+                    .priceList(chartPriceList)
+                    .build();
+        }
+    }
+
+    public IndexChartInfoDto getIndexStatus(String marketCode) {
+        // 오늘 날짜 기준으로 API 호출하여 최신 상태 정보만 가져옴
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        // API 호출 시 dateType은 'D'로 고정
+        IndexChartResponseDto response = fetchIndexChartFromApi(marketCode, today, "D");
+        return response.getInfo();
+    }
+
+    private IndexChartPriceDto convertToDto(IndexDailyData entity) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+        return IndexChartPriceDto.builder()
+                .date(entity.getDate().format(formatter))
+                .price(entity.getClosingPrice().toString())
+                .openPrice(entity.getOpeningPrice().toString())
+                .highPrice(entity.getHighPrice().toString())
+                .lowPrice(entity.getLowPrice().toString())
+                .build();
+    }
+
+    // 실제 API 호출 메서드 (Private or Internal use)
+    private IndexChartResponseDto fetchIndexChartFromApi(String marketCode, String date, String dateType) {
+        // 1. 토큰 처리 (Bearer가 이미 붙어있는지 확인 필요)
+        String accessToken = kisAuthService.getAccessToken();
+        String authorizationHeader = accessToken.startsWith("Bearer ") ? accessToken : "Bearer " + accessToken;
+
+        String fidInputIscd = switch (marketCode.toUpperCase()) {
+            case "KOSPI" -> "0001";
+            case "KOSDAQ" -> "1001";
+            default -> throw new BusinessException(KisApiErrorCode.INVALID_MARKET_CODE);
+        };
+
+        KisIndexChartApiResponse apiResponse = webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(kisApiProperties.getIndexChartUrl()) // url 확인:
+                        // /uapi/domestic-stock/v1/quotations/inquire-index-daily-price
+                        .queryParam("FID_PERIOD_DIV_CODE", dateType) // D : 일별, W : 주별, M : 월별
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "U")
+                        .queryParam("FID_INPUT_ISCD", fidInputIscd) // KOSPI
+                        .queryParam("FID_INPUT_DATE_1", date)
+                        .build())
+                .header("authorization", authorizationHeader) // [수정] 명확한 변수명 사용 및 Bearer 접두사 한번만 붙도록 보장
+                .header("appkey", kisApiProperties.getAppkey())
+                .header("appsecret", kisApiProperties.getAppsecret())
+                .header("tr_id", "FHPUP02120000")
+                .header("custtype", "P") // [중요] 고객 타입 추가 (P: 개인)
+                .retrieve()
+                .bodyToMono(KisIndexChartApiResponse.class)
+                .onErrorMap(error -> {
+                    // 로깅을 통해 실제 API가 뱉는 에러 메시지를 확인하는 것이 좋습니다.
+                    log.error("KIS API Error for {}: {}", marketCode, error.getMessage());
+                    return new BusinessException(KisApiErrorCode.INDEX_FETCH_FAILED);
+                })
+                .block();
+
+        // 응답 검증 강화 (output1이 null이거나 비어있으면 실패로 간주)
+        if (apiResponse == null || !"0".equals(apiResponse.getRtCd())) { // Check rtCd for success
+            log.error("API Response is valid but list is empty. Msg: {}",
+                    apiResponse != null ? apiResponse.getMsg1() : "null response");
+            throw new BusinessException(KisApiErrorCode.INDEX_FETCH_FAILED);
+        }
+
+        IndexChartInfoDto chartInfoDto = IndexChartInfoDto.builder()
+                .marketName(marketCode.toUpperCase())
+                .currentIndices(apiResponse.getTodayInfo().getCurrentIndices())
+                .priceChange(apiResponse.getTodayInfo().getPriceChange())
+                .changeRate(apiResponse.getTodayInfo().getChangeRate())
+                .build();
+
+        List<IndexChartPriceDto> chartPriceList = apiResponse.getDateInfoList().stream()
+                .map(apiPrice -> IndexChartPriceDto.builder()
+                        .date(apiPrice.getDate())
+                        .price(apiPrice.getPrice())
+                        .openPrice(apiPrice.getOpenPrice())
+                        .highPrice(apiPrice.getHighPrice())
+                        .lowPrice(apiPrice.getLowPrice())
+                        .build())
+                .collect(Collectors.toList());
+
+        return IndexChartResponseDto.builder()
+                .info(chartInfoDto)
+                .priceList(chartPriceList)
+                .build();
+
+    }
+}

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/kisService/KisStockService.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/kisService/KisStockService.java
@@ -1,14 +1,11 @@
 package com.AISA.AISA.kisStock.kisService;
 
 import com.AISA.AISA.kisStock.Entity.stock.Stock;
-import com.AISA.AISA.kisStock.repository.IndexDailyDataRepository;
+import com.AISA.AISA.kisStock.dto.StockPrice.*;
 import com.AISA.AISA.kisStock.repository.StockRepository;
+import com.AISA.AISA.kisStock.Entity.stock.StockDailyData;
+import com.AISA.AISA.kisStock.repository.StockDailyDataRepository;
 import com.AISA.AISA.kisStock.config.KisApiProperties;
-import com.AISA.AISA.kisStock.dto.Index.*;
-import com.AISA.AISA.kisStock.Entity.Index.IndexDailyData;
-import com.AISA.AISA.kisStock.dto.StockPrice.KisPriceApiResponse;
-import com.AISA.AISA.kisStock.dto.StockPrice.StockPriceDto;
-import com.AISA.AISA.kisStock.dto.StockPrice.StockPriceResponse;
 import com.AISA.AISA.kisStock.exception.KisApiErrorCode;
 import com.AISA.AISA.kisStock.kisService.Auth.KisAuthService;
 import com.AISA.AISA.global.exception.BusinessException;
@@ -22,6 +19,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,7 +31,7 @@ public class KisStockService {
         private final KisAuthService kisAuthService;
         private final KisApiProperties kisApiProperties;
         private final StockRepository stockRepository;
-        private final IndexDailyDataRepository indexDailyDataRepository;
+        private final StockDailyDataRepository stockDailyDataRepository;
 
         public StockPriceDto getStockPrice(String stockCode) {
                 String accessToken = kisAuthService.getAccessToken();
@@ -74,299 +72,289 @@ public class KisStockService {
                                 raw.getOpeningPriceRaw());
         }
 
-        @Transactional
-        public void fetchAndSaveHistoricalData(String marketCode, String startDateStr) {
+        public StockChartResponseDto getStockChart(String stockCode, String startDate, String endDate,
+                        String dateType) {
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
-                LocalDate targetStartDate = LocalDate.parse(startDateStr, formatter);
-                LocalDate currentDate = LocalDate.now();
+                LocalDate targetStartDate = LocalDate.parse(startDate, formatter);
+                LocalDate targetEndDate = LocalDate.parse(endDate, formatter);
 
-                log.info("Starting historical data fetch for {} from {} to {}", marketCode, currentDate,
-                                targetStartDate);
+                Stock stock = stockRepository.findByStockCode(stockCode)
+                                .orElseThrow(() -> new BusinessException(KisApiErrorCode.STOCK_NOT_FOUND));
 
-                while (currentDate.isAfter(targetStartDate)) {
-                        String currentDateStr = currentDate.format(formatter);
-                        log.info("Fetching data for date: {}", currentDateStr);
+                try {
+                        // 1. API에서 최신 데이터 조회 (최대 100건)
+                        // endDate를 기준으로 데이터를 요청합니다.
+                        // 100건의 거래일이 정확히 며칠인지 알 수 없으므로, 넉넉한 기간(예: 150일)을 설정하여 요청합니다.
+                        // API는 범위 내에서 최신 100건을 반환하거나, 범위가 너무 넓으면 에러를 반환할 수 있습니다.
+                        // 여기서는 [max(startDate, endDate-150days), endDate] 범위로 요청합니다.
+                        LocalDate apiStartDate = targetEndDate.minusDays(150);
+                        if (apiStartDate.isBefore(targetStartDate)) {
+                                apiStartDate = targetStartDate;
+                        }
+                        String apiStartDateStr = apiStartDate.format(formatter);
 
-                        try {
-                                // 1. API 호출 및 데이터 가져오기
-                                IndexChartResponseDto response = fetchIndexChartFromApi(marketCode, currentDateStr,
-                                                "D");
+                        StockChartResponseDto apiResponse = fetchStockChartFromApi(stockCode, apiStartDateStr, endDate,
+                                        dateType);
 
-                                if (response.getPriceList() == null || response.getPriceList().isEmpty()) {
-                                        log.warn("No data returned for date: {}. Stopping.", currentDateStr);
-                                        break;
-                                }
-
-                                // 2. 데이터 저장
-                                for (IndexChartPriceDto priceDto : response.getPriceList()) {
+                        // 2. API 데이터를 DB에 저장
+                        if (apiResponse.getPriceList() != null && !apiResponse.getPriceList().isEmpty()) {
+                                for (StockChartPriceDto priceDto : apiResponse.getPriceList()) {
                                         LocalDate parsedDate = LocalDate.parse(priceDto.getDate(), formatter);
-
-                                        // 이미 저장된 데이터가 있으면 건너뛰기 (옵션)
-                                        if (indexDailyDataRepository.findByMarketNameAndDate(marketCode, parsedDate)
+                                        if (stockDailyDataRepository.findByStockAndDate(stock, parsedDate)
                                                         .isPresent()) {
                                                 continue;
                                         }
 
-                                        IndexDailyData entity = IndexDailyData.builder()
-                                                        .marketName(marketCode)
+                                        StockDailyData entity = StockDailyData.builder()
+                                                        .stock(stock)
                                                         .date(parsedDate)
-                                                        .closingPrice(new BigDecimal(priceDto.getPrice()))
+                                                        .closingPrice(new BigDecimal(priceDto.getClosePrice()))
                                                         .openingPrice(new BigDecimal(priceDto.getOpenPrice()))
                                                         .highPrice(new BigDecimal(priceDto.getHighPrice()))
                                                         .lowPrice(new BigDecimal(priceDto.getLowPrice()))
-                                                        .priceChange(BigDecimal.ZERO)
-                                                        .changeRate(0.0)
-                                                        .volume(BigDecimal.ZERO)
+                                                        .volume(new BigDecimal(priceDto.getVolume()))
+                                                        .priceChange(null)
+                                                        .changeRate(null)
                                                         .build();
-
-                                        indexDailyDataRepository.save(entity);
+                                        stockDailyDataRepository.save(entity);
                                 }
-
-                                // 3. 다음 호출을 위해 날짜 갱신 (가장 과거 날짜 - 1일)
-                                String oldestDateStr = response.getPriceList().get(response.getPriceList().size() - 1)
-                                                .getDate();
-                                LocalDate oldestDate = LocalDate.parse(oldestDateStr, formatter);
-
-                                if (!oldestDate.isBefore(currentDate)) {
-                                        // 무한 루프 방지: API가 계속 같은 날짜를 반환하거나 이상할 경우
-                                        log.warn("Oldest date {} is not before current date {}. Stopping to prevent infinite loop.",
-                                                        oldestDate, currentDate);
-                                        break;
-                                }
-
-                                currentDate = oldestDate.minusDays(1);
-
-                                // API 호출 제한 고려 (0.1초 대기)
-                                Thread.sleep(100);
-
-                        } catch (Exception e) {
-                                log.error("Error fetching historical data for {}: {}", currentDateStr, e.getMessage());
-                                break; // 에러 발생 시 중단
-                        }
-                }
-                log.info("Finished historical data fetch for {}", marketCode);
-        }
-
-        @Transactional
-        public void saveIndexDailyData(String marketCode, String date, String dateType) {
-                IndexChartResponseDto response = fetchIndexChartFromApi(marketCode, date, dateType);
-
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
-
-                for (IndexChartPriceDto priceDto : response.getPriceList()) {
-                        LocalDate parsedDate = LocalDate.parse(priceDto.getDate(), formatter);
-
-                        if (indexDailyDataRepository.findByMarketNameAndDate(marketCode, parsedDate).isPresent()) {
-                                continue;
                         }
 
-                        IndexDailyData entity = IndexDailyData.builder()
-                                        .marketName(marketCode)
-                                        .date(parsedDate)
-                                        .closingPrice(new BigDecimal(priceDto.getPrice()))
-                                        .openingPrice(new BigDecimal(priceDto.getOpenPrice()))
-                                        .highPrice(new BigDecimal(priceDto.getHighPrice()))
-                                        .lowPrice(new BigDecimal(priceDto.getLowPrice()))
-                                        .priceChange(BigDecimal.ZERO) // DTO에 없으면 0 또는 계산
-                                        .changeRate(0.0) // DTO에 없으면 0 또는 계산
-                                        .volume(BigDecimal.ZERO) // DTO에 volume이 없다면 0 처리, 있다면 new
-                                                                 // BigDecimal(priceDto.getVolume())
-                                        .build();
-
-                        indexDailyDataRepository.save(entity);
-                }
-        }
-
-        // DB에서 조회하는 메서드 (Controller에서 사용)
-        public IndexChartResponseDto getIndexChart(String marketCode, String startDate, String endDate,
-                        String dateType) {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
-                LocalDate targetEndDate = LocalDate.parse(endDate, formatter);
-                LocalDate targetStartDate = LocalDate.parse(startDate, formatter);
-
-                try {
-                        // 1. 실시간 데이터(API) 시도 (endDate 기준 100건)
-                        IndexChartResponseDto apiResponse = fetchIndexChartFromApi(marketCode, endDate, dateType);
-
-                        // API 데이터가 없으면 DB만 조회
-                        if (apiResponse.getPriceList() == null || apiResponse.getPriceList().isEmpty()) {
-                                throw new BusinessException(KisApiErrorCode.INDEX_FETCH_FAILED);
+                        // 3. 요청된 기간에 맞게 API 데이터 필터링
+                        List<StockChartPriceDto> filteredApiList = new ArrayList<>();
+                        if (apiResponse.getPriceList() != null) {
+                                filteredApiList = apiResponse.getPriceList().stream()
+                                                .filter(dto -> {
+                                                        LocalDate dtoDate = LocalDate.parse(dto.getDate(), formatter);
+                                                        return !dtoDate.isBefore(targetStartDate)
+                                                                        && !dtoDate.isAfter(targetEndDate);
+                                                })
+                                                .collect(Collectors.toList());
                         }
 
-                        // 2. API 데이터 필터링 (startDate보다 이후인 데이터만 사용)
-                        List<IndexChartPriceDto> filteredApiList = apiResponse.getPriceList().stream()
-                                        .filter(dto -> {
-                                                LocalDate dtoDate = LocalDate.parse(dto.getDate(), formatter);
-                                                return !dtoDate.isBefore(targetStartDate)
-                                                                && !dtoDate.isAfter(targetEndDate);
-                                        })
-                                        .toList();
-
-                        // 3. 부족한 과거 데이터 DB 조회
-                        List<IndexChartPriceDto> dbPriceList = new ArrayList<>();
-
-                        // API 데이터가 있고, 가장 오래된 날짜가 startDate보다 아직 미래라면 -> 그 사이 공백을 DB로 채움
+                        // 4. 부족한 과거 데이터를 DB에서 조회
+                        List<StockChartPriceDto> dbPriceList = new ArrayList<>();
                         if (!filteredApiList.isEmpty()) {
                                 String oldestApiDateStr = filteredApiList.get(filteredApiList.size() - 1).getDate();
                                 LocalDate oldestApiDate = LocalDate.parse(oldestApiDateStr, formatter);
 
                                 if (oldestApiDate.isAfter(targetStartDate)) {
-                                        List<IndexDailyData> pastDataList = indexDailyDataRepository
-                                                        .findAllByMarketNameAndDateBetweenOrderByDateDesc(
-                                                                        marketCode, targetStartDate,
+                                        List<StockDailyData> pastDataList = stockDailyDataRepository
+                                                        .findAllByStock_StockCodeAndDateBetweenOrderByDateDesc(
+                                                                        stockCode, targetStartDate,
                                                                         oldestApiDate.minusDays(1));
-
                                         dbPriceList = pastDataList.stream()
                                                         .map(this::convertToDto)
                                                         .collect(Collectors.toList());
                                 }
                         } else {
-                                // API 데이터가 startDate 범위에 하나도 없으면 (API가 너무 미래 데이터만 줬거나 등)
-                                // DB에서 전체 범위 조회 시도 (API가 준 데이터의 가장 오래된 날짜보다 더 과거를 요청했을 수 있음)
-                                // 하지만 fetchIndexChartFromApi는 endDate 기준 100개를 주므로,
-                                // endDate가 startDate보다 훨씬 미래라면 API 데이터가 startDate를 커버하지 못할 수 있음.
-                                // 이 경우 API 데이터 전체(100개) + 그 이전 DB 데이터를 합쳐야 하는데,
-                                // 여기서는 단순하게 "API가 커버하지 못하는 영역"을 DB에서 가져오는 로직으로 처리
-
-                                // API가 반환한 가장 오래된 날짜 확인
-                                String apiOldestRaw = apiResponse.getPriceList()
-                                                .get(apiResponse.getPriceList().size() - 1).getDate();
-                                LocalDate apiOldestDate = LocalDate.parse(apiOldestRaw, formatter);
-
-                                if (apiOldestDate.isAfter(targetStartDate)) {
-                                        List<IndexDailyData> pastDataList = indexDailyDataRepository
-                                                        .findAllByMarketNameAndDateBetweenOrderByDateDesc(
-                                                                        marketCode, targetStartDate,
-                                                                        apiOldestDate.minusDays(1));
-                                        dbPriceList = pastDataList.stream()
-                                                        .map(this::convertToDto)
-                                                        .collect(Collectors.toList());
-                                }
+                                // API가 범위 내 데이터를 반환하지 않았거나, 요청 범위가 API의 최신 100건 범위를 완전히 벗어난 경우
+                                // DB에서 전체 데이터를 조회 시도
+                                List<StockDailyData> pastDataList = stockDailyDataRepository
+                                                .findAllByStock_StockCodeAndDateBetweenOrderByDateDesc(
+                                                                stockCode, targetStartDate, targetEndDate);
+                                dbPriceList = pastDataList.stream()
+                                                .map(this::convertToDto)
+                                                .collect(Collectors.toList());
                         }
 
-                        // 4. 데이터 병합
-                        List<IndexChartPriceDto> mergedList = new ArrayList<>(filteredApiList);
+                        // 5. 병합 (API 데이터는 내림차순, DB 데이터도 내림차순)
+                        // API 데이터: [최신 ... 과거]
+                        // DB 데이터: [최신 ... 과거] (범위: [Start, OldestApi - 1])
+                        // 따라서 API 리스트 뒤에 DB 리스트를 추가합니다.
+                        List<StockChartPriceDto> mergedList = new ArrayList<>(filteredApiList);
                         mergedList.addAll(dbPriceList);
 
-                        return IndexChartResponseDto.builder()
-                                        .info(apiResponse.getInfo())
+                        return StockChartResponseDto.builder()
+                                        .rtCd(apiResponse.getRtCd())
+                                        .msg1(apiResponse.getMsg1())
                                         .priceList(mergedList)
                                         .build();
 
                 } catch (Exception e) {
-                        log.warn("Failed to fetch from API, falling back to DB: {}", e.getMessage());
-
-                        // API 실패 시 DB에서 전체 범위 조회
-                        List<IndexDailyData> entityList = indexDailyDataRepository
-                                        .findAllByMarketNameAndDateBetweenOrderByDateDesc(marketCode, targetStartDate,
-                                                        targetEndDate);
-
-                        if (entityList.isEmpty()) {
-                                throw new BusinessException(KisApiErrorCode.INDEX_FETCH_FAILED);
-                        }
-
-                        IndexDailyData todayData = entityList.get(0);
-
-                        IndexChartInfoDto chartInfoDto = IndexChartInfoDto.builder()
-                                        .marketName(marketCode.toUpperCase())
-                                        .currentIndices(todayData.getClosingPrice().toString())
-                                        .priceChange(todayData.getPriceChange().toString())
-                                        .changeRate(todayData.getChangeRate().toString())
-                                        .build();
-
-                        List<IndexChartPriceDto> chartPriceList = entityList.stream()
+                        log.warn("API 조회 실패, DB 데이터로 대체합니다: {}", e.getMessage());
+                        // 대체: DB에서 전체 조회
+                        List<StockDailyData> pastDataList = stockDailyDataRepository
+                                        .findAllByStock_StockCodeAndDateBetweenOrderByDateDesc(
+                                                        stockCode, targetStartDate, targetEndDate);
+                        List<StockChartPriceDto> dbPriceList = pastDataList.stream()
                                         .map(this::convertToDto)
                                         .collect(Collectors.toList());
 
-                        return IndexChartResponseDto.builder()
-                                        .info(chartInfoDto)
-                                        .priceList(chartPriceList)
+                        return StockChartResponseDto.builder()
+                                        .rtCd("0")
+                                        .msg1("Fetched from DB (Fallback)")
+                                        .priceList(dbPriceList)
                                         .build();
                 }
         }
 
-        public IndexChartInfoDto getIndexStatus(String marketCode) {
-                // 오늘 날짜 기준으로 API 호출하여 최신 상태 정보만 가져옴
-                String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-                // API 호출 시 dateType은 'D'로 고정
-                IndexChartResponseDto response = fetchIndexChartFromApi(marketCode, today, "D");
-                return response.getInfo();
-        }
-
-        private IndexChartPriceDto convertToDto(IndexDailyData entity) {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
-                return IndexChartPriceDto.builder()
-                                .date(entity.getDate().format(formatter))
-                                .price(entity.getClosingPrice().toString())
-                                .openPrice(entity.getOpeningPrice().toString())
-                                .highPrice(entity.getHighPrice().toString())
-                                .lowPrice(entity.getLowPrice().toString())
-                                .build();
-        }
-
-        // 실제 API 호출 메서드 (Private or Internal use)
-        private IndexChartResponseDto fetchIndexChartFromApi(String marketCode, String date, String dateType) {
-                // 1. 토큰 처리 (Bearer가 이미 붙어있는지 확인 필요)
+        private StockChartResponseDto fetchStockChartFromApi(String stockCode,
+                        String startDate, String endDate, String dateType) {
                 String accessToken = kisAuthService.getAccessToken();
-                String authorizationHeader = accessToken.startsWith("Bearer ") ? accessToken : "Bearer " + accessToken;
 
-                String fidInputIscd = switch (marketCode.toUpperCase()) {
-                        case "KOSPI" -> "0001";
-                        case "KOSDAQ" -> "1001";
-                        default -> throw new BusinessException(KisApiErrorCode.INVALID_MARKET_CODE);
-                };
+                StockChartResponseDto apiResponse;
+                try {
+                        apiResponse = webClient.get()
+                                        .uri(uriBuilder -> uriBuilder
+                                                        .path(kisApiProperties.getStockChartUrl())
+                                                        .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                                                        .queryParam("FID_INPUT_ISCD", stockCode)
+                                                        .queryParam("FID_INPUT_DATE_1", startDate)
+                                                        .queryParam("FID_INPUT_DATE_2", endDate)
+                                                        .queryParam("FID_PERIOD_DIV_CODE", dateType)
+                                                        .queryParam("FID_ORG_ADJ_PRC", "0")
+                                                        .build())
+                                        .header("authorization", accessToken)
+                                        .header("appkey", kisApiProperties.getAppkey())
+                                        .header("appsecret", kisApiProperties.getAppsecret())
+                                        .header("tr_id", "FHKST03010100")
+                                        .header("custtype", "P")
+                                        .retrieve()
+                                        .bodyToMono(StockChartResponseDto.class)
+                                        .block();
+                } catch (Exception e) {
+                        log.error("KIS API WebClient Error for {}: {}", stockCode, e.getMessage(), e);
+                        throw new BusinessException(KisApiErrorCode.INDEX_FETCH_FAILED);
+                }
 
-                KisIndexChartApiResponse apiResponse = webClient.get()
-                                .uri(uriBuilder -> uriBuilder
-                                                .path(kisApiProperties.getIndexChartUrl()) // url 확인:
-                                                                                           // /uapi/domestic-stock/v1/quotations/inquire-index-daily-price
-                                                .queryParam("FID_PERIOD_DIV_CODE", dateType) // D : 일별, W : 주별, M : 월별
-                                                .queryParam("FID_COND_MRKT_DIV_CODE", "U")
-                                                .queryParam("FID_INPUT_ISCD", fidInputIscd) // KOSPI
-                                                .queryParam("FID_INPUT_DATE_1", date)
-                                                .build())
-                                .header("authorization", authorizationHeader) // [수정] 명확한 변수명 사용 및 Bearer 접두사 한번만 붙도록 보장
-                                .header("appkey", kisApiProperties.getAppkey())
-                                .header("appsecret", kisApiProperties.getAppsecret())
-                                .header("tr_id", "FHPUP02120000")
-                                .header("custtype", "P") // [중요] 고객 타입 추가 (P: 개인)
-                                .retrieve()
-                                .bodyToMono(KisIndexChartApiResponse.class)
-                                .onErrorMap(error -> {
-                                        // 로깅을 통해 실제 API가 뱉는 에러 메시지를 확인하는 것이 좋습니다.
-                                        log.error("KIS API Error for {}: {}", marketCode, error.getMessage());
-                                        return new BusinessException(KisApiErrorCode.INDEX_FETCH_FAILED);
-                                })
-                                .block();
-
-                // 응답 검증 강화 (output1이 null이거나 비어있으면 실패로 간주)
-                if (apiResponse == null || !"0".equals(apiResponse.getRtCd())) { // Check rtCd for success
-                        log.error("API Response is valid but list is empty. Msg: {}",
+                if (apiResponse == null || !"0".equals(apiResponse.getRtCd())) {
+                        log.error("API Response is valid but list is empty or error. RtCd: {}, Msg: {}",
+                                        apiResponse != null ? apiResponse.getRtCd() : "null",
                                         apiResponse != null ? apiResponse.getMsg1() : "null response");
                         throw new BusinessException(KisApiErrorCode.INDEX_FETCH_FAILED);
                 }
 
-                IndexChartInfoDto chartInfoDto = IndexChartInfoDto.builder()
-                                .marketName(marketCode.toUpperCase())
-                                .currentIndices(apiResponse.getTodayInfo().getCurrentIndices())
-                                .priceChange(apiResponse.getTodayInfo().getPriceChange())
-                                .changeRate(apiResponse.getTodayInfo().getChangeRate())
-                                .build();
-
-                List<IndexChartPriceDto> chartPriceList = apiResponse.getDateInfoList().stream()
-                                .map(apiPrice -> IndexChartPriceDto.builder()
-                                                .date(apiPrice.getDate())
-                                                .price(apiPrice.getPrice())
-                                                .openPrice(apiPrice.getOpenPrice())
-                                                .highPrice(apiPrice.getHighPrice())
-                                                .lowPrice(apiPrice.getLowPrice())
-                                                .build())
-                                .collect(Collectors.toList());
-
-                return IndexChartResponseDto.builder()
-                                .info(chartInfoDto)
-                                .priceList(chartPriceList)
-                                .build();
-
+                return apiResponse;
         }
+
+        @Transactional
+        public void fetchAndSaveHistoricalStockData(String stockCode, String startDateStr) {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+                LocalDate targetStartDate = LocalDate.parse(startDateStr, formatter);
+                LocalDate currentDate = LocalDate.now();
+
+                log.info("Starting historical stock data fetch for {} from {} to {}", stockCode, currentDate,
+                                targetStartDate);
+
+                Stock stock = stockRepository.findByStockCode(stockCode)
+                                .orElseThrow(() -> new BusinessException(KisApiErrorCode.STOCK_NOT_FOUND));
+
+                int consecutiveFailures = 0;
+                final int MAX_CONSECUTIVE_FAILURES = 5;
+
+                while (currentDate.isAfter(targetStartDate)) {
+                        String currentDateStr = currentDate.format(formatter);
+
+                        LocalDate queryStartDate = currentDate.minusDays(100);
+                        if (queryStartDate.isBefore(targetStartDate)) {
+                                queryStartDate = targetStartDate;
+                        }
+                        String queryStartDateStr = queryStartDate.format(formatter);
+
+                        log.info("Fetching data for {} from {} to {}", stockCode, queryStartDateStr, currentDateStr);
+
+                        try {
+                                StockChartResponseDto response = fetchStockChartFromApi(stockCode, queryStartDateStr,
+                                                currentDateStr, "D");
+
+                                if (response.getPriceList() == null || response.getPriceList().isEmpty()) {
+                                        log.warn("No data returned for {} from {} to {}. Retrying with previous period.",
+                                                        stockCode, queryStartDateStr, currentDateStr);
+                                        // Move back
+                                        currentDate = queryStartDate.minusDays(1);
+                                        consecutiveFailures++;
+                                        if (consecutiveFailures > MAX_CONSECUTIVE_FAILURES) {
+                                                log.error("Too many consecutive failures ({}). Stopping.",
+                                                                consecutiveFailures);
+                                                break;
+                                        }
+                                        continue;
+                                }
+
+                                consecutiveFailures = 0;
+
+                                for (StockChartPriceDto priceDto : response.getPriceList()) {
+                                        LocalDate parsedDate = LocalDate.parse(priceDto.getDate(), formatter);
+
+                                        if (stockDailyDataRepository.findByStockAndDate(stock, parsedDate)
+                                                        .isPresent()) {
+                                                continue;
+                                        }
+
+                                        StockDailyData entity = StockDailyData.builder()
+                                                        .stock(stock)
+                                                        .date(parsedDate)
+                                                        .closingPrice(new BigDecimal(priceDto.getClosePrice()))
+                                                        .openingPrice(new BigDecimal(priceDto.getOpenPrice()))
+                                                        .highPrice(new BigDecimal(priceDto.getHighPrice()))
+                                                        .lowPrice(new BigDecimal(priceDto.getLowPrice()))
+                                                        .volume(new BigDecimal(priceDto.getVolume()))
+                                                        .priceChange(null) // DTO에 아직 없음
+                                                        .changeRate(null) // DTO에 아직 없음
+                                                        .build();
+
+                                        stockDailyDataRepository.save(entity);
+                                }
+
+                                // Update currentDate to the day before the oldest fetched date
+                                String oldestDateStr = response.getPriceList().get(response.getPriceList().size() - 1)
+                                                .getDate();
+                                LocalDate oldestDate = LocalDate.parse(oldestDateStr, formatter);
+
+                                if (!oldestDate.isBefore(currentDate)) {
+                                        // API가 동일한 날짜 범위를 반환하여 무한 루프에 빠지는 것을 방지
+                                        log.warn("가장 오래된 날짜 {}가 현재 날짜 {}보다 이전이 아닙니다. 수동으로 이동합니다.",
+                                                        oldestDate, currentDate);
+                                        currentDate = currentDate.minusDays(100);
+                                } else {
+                                        currentDate = oldestDate.minusDays(1);
+                                }
+
+                                Thread.sleep(100); // 속도 제한
+
+                        } catch (Exception e) {
+                                log.error("Error fetching historical data for {}: {}", stockCode, e.getMessage());
+                                currentDate = currentDate.minusDays(1); // 뒤로 이동 시도
+                                consecutiveFailures++;
+                                if (consecutiveFailures > MAX_CONSECUTIVE_FAILURES) {
+                                        break;
+                                }
+                        }
+                }
+                log.info("Finished historical stock data fetch for {}", stockCode);
+        }
+
+        public void fetchAllStocksHistoricalData(String startDateStr) {
+                log.info("Starting batch historical stock data fetch from {}", startDateStr);
+                List<Stock> allStocks = stockRepository.findAll();
+
+                for (Stock stock : allStocks) {
+                        try {
+                                log.info("Updating data for stock: {} ({})", stock.getStockName(),
+                                                stock.getStockCode());
+                                fetchAndSaveHistoricalStockData(stock.getStockCode(), startDateStr);
+
+                                // API 과부하 방지를 위한 지연 추가
+                                Thread.sleep(500);
+                        } catch (Exception e) {
+                                log.error("Failed to update stock: {} ({}) - {}", stock.getStockName(),
+                                                stock.getStockCode(), e.getMessage());
+                        }
+                }
+                log.info("Completed batch historical stock data fetch.");
+        }
+
+        private StockChartPriceDto convertToDto(StockDailyData entity) {
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+                return StockChartPriceDto.builder()
+                                .date(entity.getDate().format(formatter))
+                                .closePrice(entity.getClosingPrice().toString())
+                                .openPrice(entity.getOpeningPrice().toString())
+                                .highPrice(entity.getHighPrice().toString())
+                                .lowPrice(entity.getLowPrice().toString())
+                                .volume(entity.getVolume().toString())
+                                .build();
+        }
+
 }

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/repository/StockDailyDataRepository.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/repository/StockDailyDataRepository.java
@@ -1,0 +1,19 @@
+package com.AISA.AISA.kisStock.repository;
+
+import com.AISA.AISA.kisStock.Entity.stock.Stock;
+import com.AISA.AISA.kisStock.Entity.stock.StockDailyData;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface StockDailyDataRepository extends JpaRepository<StockDailyData, Long> {
+    Optional<StockDailyData> findByStockAndDate(Stock stock, LocalDate date);
+
+    List<StockDailyData> findAllByStock_StockCodeAndDateBetweenOrderByDateDesc(
+            String stockCode, LocalDate startDate, LocalDate endDate);
+
+    List<StockDailyData> findAllByStockInAndDateBetweenOrderByDateAsc(
+            List<Stock> stocks, LocalDate startDate, LocalDate endDate);
+}

--- a/AISA/src/main/java/com/AISA/AISA/kisStock/scheduler/StockScheduler.java
+++ b/AISA/src/main/java/com/AISA/AISA/kisStock/scheduler/StockScheduler.java
@@ -9,35 +9,24 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class StockScheduler {
 
     private final KisStockService kisStockService;
 
-    // 매일 오후 4시 30분(16:30)에 실행 (장 마감 후)
-    @Scheduled(cron = "0 30 16 * * *")
-    public void scheduleDailyIndexFetch() {
-        log.info("Starting daily index data fetch...");
+    // Run at 2 AM every day
+    @Scheduled(cron = "0 0 2 * * *")
+    public void updateAllStockData() {
+        log.info("Starting scheduled stock data update...");
 
-        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        // Fetch data for the last 3 years (approx 1000 days)
+        LocalDate targetStartDate = LocalDate.now().minusYears(3);
+        String targetStartDateStr = targetStartDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 
-        try {
-            // KOSPI
-            log.info("Fetching daily KOSPI data for {}", today);
-            kisStockService.saveIndexDailyData("KOSPI", today, "D");
+        kisStockService.fetchAllStocksHistoricalData(targetStartDateStr);
 
-            // API 호출 제한 고려 (잠시 대기)
-            Thread.sleep(1000);
-
-            // KOSDAQ
-            log.info("Fetching daily KOSDAQ data for {}", today);
-            kisStockService.saveIndexDailyData("KOSDAQ", today, "D");
-
-            log.info("Daily index data fetch completed successfully.");
-        } catch (Exception e) {
-            log.error("Failed to fetch daily index data: {}", e.getMessage());
-        }
+        log.info("Completed scheduled stock data update.");
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- close #이슈번호 -->

close #52 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요.  -->

1. 주식 과거 데이터 조회 기능 추가
1-1. 처음에는 한국투자증권 API에서 조회하기만 했으나, 100회 조회 제한 문제가 발생함.
1-2. 우리 DB에 주가 데이터를 저장
1-3. 약 100일간의 데이터는 한국투자증권 API를 조회하고, 더 이전의 과거 데이터는 우리 DB에서 조회하는 방식으로 구현
2. 지수와 주가 패키지 분리

## 🛠️ PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [X] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸 스크린샷 (선택)

## ✅ PR Checklist

- [X] PR 제목 규칙에 맞게 작성 했나요?
- [X] 관련된 이슈 번호를 작성했나요? (<!--- close #이슈번호 -->)
- [X] 모든 변경 사항을 다시 한번 검토했나요?
